### PR TITLE
Updated aws-sdk to version 2.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/ghaiklor/sails-service-storage#readme",
   "dependencies": {
-    "aws-sdk": "2.2.6",
+    "aws-sdk": "2.2.7",
     "lodash": "3.10.1",
     "mkdirp": "0.5.1"
   },


### PR DESCRIPTION
:rocket:

aws-sdk just published version 2.2.7, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 7 commits (ahead by 7, behind by 0).

- [2dcbc29](https://github.com/aws/aws-sdk-js/commit/2dcbc29ade5ace5c80662c70d440d98c26b41c8c): Tag release v2.2.7
- [76b7b88](https://github.com/aws/aws-sdk-js/commit/76b7b88076740ff693d6c7c4c17565c346ddc14a): Added AWS.WAF to Browser Services list
- [dba453d](https://github.com/aws/aws-sdk-js/commit/dba453d57493f27d2c84876cdddbaa87e87d3e46): Added WAF to list of default services
- [e4d02b8](https://github.com/aws/aws-sdk-js/commit/e4d02b828df53208224e545803389077688eb279): Updated tests for AWS.WAF
- [7d1be49](https://github.com/aws/aws-sdk-js/commit/7d1be490bad842506e3bc9c116478ff2f0062c1f): Update AWS.CloudFront API
- [81fda5f](https://github.com/aws/aws-sdk-js/commit/81fda5f4276ab228c09d281acaefe0e3c0197b48): Update AWS.WAF API
- [8ed553c](https://github.com/aws/aws-sdk-js/commit/8ed553c8968d64dad7996ed23c1e05cb42b88f80): Update AWS.EC2 API

See the [full diff](https://github.com/aws/aws-sdk-js/compare/70d2f084f432fcbff0b774476d76a4a8d0cee8cb...2dcbc29ade5ace5c80662c70d440d98c26b41c8c).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>